### PR TITLE
Configured iOS for Google Maps API integration

### DIFF
--- a/google_maps_app/ios/Runner/AppDelegate.swift
+++ b/google_maps_app/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import GoogleMaps
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,6 +8,7 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    GMSServices.provideAPIKey("YOUR KEY HERE")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }


### PR DESCRIPTION
This PR includes the necessary iOS configurations for integrating Google Maps into the Flutter project. The following changes were made:

- Updated the `AppDelegate.swift` file to include the Google Maps SDK.
- The necessary module (`GoogleMaps`) was imported.
- Configured the Google Maps API key by adding `GMSServices.provideAPIKey("YOUR KEY HERE")` in the `application(_:didFinishLaunchingWithOptions:)` method.

These configurations are crucial for enabling map functionalities, such as displaying maps and markers, in the iOS version of the app.
