### PR TITLE
Updated Kotlin Gradle plugin to the latest version to resolve compatibility issue with Location package

### DIFF
--- a/google_maps_app/android/settings.gradle
+++ b/google_maps_app/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
This PR addresses an issue that required updating the Kotlin Gradle plugin to a newer version due to compatibility problems with the Location package. The following changes were made:

- Updated `settings.gradle` to use the latest Kotlin Gradle plugin version, as recommended in the official Kotlin documentation.
- The default version (1.7.10) was replaced with the most recent version to ensure compatibility and resolve the error related to requiring a newer version of the Kotlin Gradle plugin.

This update is necessary for maintaining functionality and compatibility when using the Location package in the project.
