### PR TITLE
Added Google Maps API key using Google Cloud APIs & Services to AndroidManifest.xml and AppDelegate.swift

### DIFF
--- a/google_maps_app/android/app/src/main/AndroidManifest.xml
+++ b/google_maps_app/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
             android:name="flutterEmbedding"
             android:value="2" />
             <meta-data android:name="com.google.android.geo.API_KEY"
-               android:value="YOUR KEY HERE"/>
+               android:value="AIzaSyCadscwOAarW37OfM1qiCWCVkmWDiFe3eM"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/google_maps_app/ios/Runner/AppDelegate.swift
+++ b/google_maps_app/ios/Runner/AppDelegate.swift
@@ -8,7 +8,7 @@ import GoogleMaps
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GMSServices.provideAPIKey("YOUR KEY HERE")
+    GMSServices.provideAPIKey("AIzaSyCadscwOAarW37OfM1qiCWCVkmWDiFe3eM")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/google_maps_app/lib/pages/map_page.dart
+++ b/google_maps_app/lib/pages/map_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 class MapPage extends StatefulWidget {
   const MapPage({super.key});
@@ -8,8 +9,14 @@ class MapPage extends StatefulWidget {
 }
 
 class _MapPageState extends State<MapPage> {
+  // Alexandria, Egypt
+  static const LatLng _pGooglePlex = LatLng(31.2156, 29.9553);
   @override
   Widget build(BuildContext context) {
-    return Scaffold();
+    return const Scaffold(
+      body: GoogleMap(
+        initialCameraPosition: CameraPosition(target: _pGooglePlex, zoom: 13),
+      ),
+    );
   }
 }

--- a/google_maps_app/pubspec.yaml
+++ b/google_maps_app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   # A flutter package to get polyline points by either passing the coordinates or google encoded polyline string
   flutter_polyline_points: ^2.1.0
 
+  
   cupertino_icons: ^1.0.8
 
 dev_dependencies:


### PR DESCRIPTION
This PR includes the integration of the Google Maps API key, obtained through Google Cloud APIs & Services, for both Android and iOS configurations. The following changes were made:

- **Android:** Added the Google Maps API key in the `AndroidManifest.xml` file under the `<meta-data>` tag.
- **iOS:** Integrated the Google Maps API key in the `AppDelegate.swift` file by adding `GMSServices.provideAPIKey("YOUR_KEY_HERE")` in the `application(_:didFinishLaunchingWithOptions:)` method.

These configurations, using API keys from Google Cloud APIs & Services, are crucial for ensuring that Google Maps appears correctly in the app. Without these keys, the maps would not render, causing a significant issue with the app's functionality.