### PR TITLE
Added location access configurations for background mode in Android and iOS

### DIFF
--- a/google_maps_app/android/app/src/main/AndroidManifest.xml
+++ b/google_maps_app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    
     <application
         android:label="google_maps_app"
         android:name="${applicationName}"

--- a/google_maps_app/ios/Runner/Info.plist
+++ b/google_maps_app/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<string>NSLocationWhenInUseUsageDescription</string>
+	<key>Want to display location on map, and track it.</key>
+	<string>NSLocationAlwaysAndWhenInUseUsageDescription</string>
+	<key>Want to display location on map, and track it.</key>
 </dict>
 </plist>

--- a/google_maps_app/lib/pages/map_page.dart
+++ b/google_maps_app/lib/pages/map_page.dart
@@ -10,12 +10,24 @@ class MapPage extends StatefulWidget {
 
 class _MapPageState extends State<MapPage> {
   // Alexandria, Egypt
-  static const LatLng _pGooglePlex = LatLng(31.2156, 29.9553);
+  static const LatLng _alexandria = LatLng(31.2156, 29.9553);
+  static const LatLng _mansoura = LatLng(31.0419, 31.3785);
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: GoogleMap(
-        initialCameraPosition: CameraPosition(target: _pGooglePlex, zoom: 13),
+        initialCameraPosition: CameraPosition(target: _alexandria, zoom: 13),
+        markers: {
+          const Marker(
+              markerId: MarkerId("_currentLocation"),
+              icon: BitmapDescriptor.defaultMarker,
+              position: _alexandria),
+          const Marker(
+              markerId: MarkerId("_sourceLocation"),
+              icon: BitmapDescriptor.defaultMarker,
+              position: _mansoura),
+        },
       ),
     );
   }


### PR DESCRIPTION
This PR includes the necessary configurations to enable location access in the background for both Android and iOS platforms. The following changes were made:

- **Android:**
  - Added required permissions in `AndroidManifest.xml` for accessing location in the background:
    - `<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />`
    - `<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>`
  - Note: Users need to manually enable the "always allow" option for background location access in Android 11 and above. This should be communicated through the app's UI, with a redirect to the app's location settings.

- **iOS:**
  - Added the following keys to `Info.plist` to enable location access:
    - `NSLocationWhenInUseUsageDescription` for general location access.
    - `NSLocationAlwaysAndWhenInUseUsageDescription` for background location access.

These changes are essential to ensure that the app can access the user's location both in the foreground and background, providing a seamless user experience for location-based features.
